### PR TITLE
Create directories in build scripts

### DIFF
--- a/build-python-build.sh
+++ b/build-python-build.sh
@@ -1,5 +1,6 @@
 #!/bin/env bash
 
+mkdir -p cpython/builddir/build
 pushd cpython/builddir/build
 ../../configure -C
 make -j$(nproc)

--- a/build-python-host-emscripten.sh
+++ b/build-python-host-emscripten.sh
@@ -2,6 +2,9 @@
 
 shopt -s extglob
 
+mkdir -p cpython/builddir/host
+mkdir -p cpython/builddir/usr/local
+
 export PYTHON_FOR_BUILD="$(pwd)/cpython/builddir/build/python"
 
 # install emcc ports so configure is able to detect the dependencies


### PR DESCRIPTION
This makes it easier to use the scripts with an existing checkout of
CPython.

Signed-off-by: Christian Heimes <christian@python.org>