### PR TITLE
Fix bz2ip2 and '-s USE' is used for linking

### DIFF
--- a/build-python-host-emscripten.sh
+++ b/build-python-host-emscripten.sh
@@ -12,7 +12,7 @@ embuilder build zlib bzip2
 
 pushd cpython/builddir/host
 cp ../../../config.site-wasm config.site-wasm
-CONFIG_SITE=config.site-wasm READELF=true ZLIB_CFLAGS="-s USE_ZLIB" emconfigure ../../configure -C --without-pymalloc --enable-big-digits=30 --with-pydebug --with-suffix=.wasm --with-ensurepip=no --disable-ipv6 --host=wasm32-unknown-emscripten --build=$(../../config.guess)
+CONFIG_SITE=config.site-wasm READELF=true ZLIB_LIBS="-s USE_ZLIB" BZIP2_LIBS="-s USE_BZIP2" emconfigure ../../configure -C --without-pymalloc --enable-big-digits=30 --with-pydebug --with-suffix=.wasm --with-ensurepip=no --disable-ipv6 --host=wasm32-unknown-emscripten --build=$(../../config.guess)
 ln -sfr Modules/Setup.stdlib Modules/Setup.local
 export FREEZE_MODULE=../build/Programs/_freeze_module
 emmake make CROSS_COMPILE=yes FREEZE_MODULE=../build/Programs/_freeze_module PYTHON_FOR_BUILD=../build/python _PYTHON_HOST_PLATFORM=wasm32-unknown-emscripten -j$(nproc)
@@ -42,5 +42,5 @@ cd ../..
 mkdir -p lib/python3.11/lib-dynload
 touch lib/python3.11/lib-dynload/.gitignore
 popd
-emcc -Os -o python.html Programs/python.o libpython3.11d.a Modules/_decimal/libmpdec/libmpdec.a Modules/expat/libexpat.a -ldl -lm -s USE_ZLIB --preload-file ../usr
+emcc -Os -o python.html Programs/python.o libpython3.11d.a Modules/_decimal/libmpdec/libmpdec.a Modules/expat/libexpat.a -ldl -lm -s USE_ZLIB -s USE_BZIP2 --preload-file ../usr
 popd


### PR DESCRIPTION
The ``-s USE_ZLIB`` and ``-s USE_BZIP2`` args are required for linking.

Signed-off-by: Christian Heimes <christian@python.org>