### PR TITLE
Don't build with bzip2

### DIFF
--- a/build-python-host-emscripten.sh
+++ b/build-python-host-emscripten.sh
@@ -6,11 +6,11 @@ mkdir -p cpython/builddir/host
 mkdir -p cpython/builddir/usr/local
 
 # install emcc ports so configure is able to detect the dependencies
-embuilder build zlib bzip2
+embuilder build zlib
 
 pushd cpython/builddir/host
 cp ../../../config.site-wasm config.site-wasm
-CONFIG_SITE=config.site-wasm READELF=true ZLIB_LIBS="-s USE_ZLIB" BZIP2_LIBS="-s USE_BZIP2" emconfigure ../../configure -C --without-pymalloc --enable-big-digits=30 --with-pydebug --with-ensurepip=no --disable-ipv6 --host=wasm32-unknown-emscripten --build=$(../../config.guess) --with-build-python=$(pwd)/../build/python --with-freeze-module=$(pwd)/../build/Programs/_freeze_module
+CONFIG_SITE=config.site-wasm READELF=true ZLIB_LIBS="-s USE_ZLIB" emconfigure ../../configure -C --without-pymalloc --enable-big-digits=30 --with-pydebug --with-ensurepip=no --disable-ipv6 --host=wasm32-unknown-emscripten --build=$(../../config.guess) --with-build-python=$(pwd)/../build/python --with-freeze-module=$(pwd)/../build/Programs/_freeze_module
 ln -sfr Modules/Setup.stdlib Modules/Setup.local
 emmake make -j$(nproc)
 make altinstall prefix=../usr/local
@@ -53,5 +53,5 @@ cd ../..
 mkdir -p lib/python3.11/lib-dynload
 touch lib/python3.11/lib-dynload/.gitignore
 popd
-emcc -Os -o python.html Programs/python.o libpython3.11d.a Modules/_decimal/libmpdec/libmpdec.a Modules/expat/libexpat.a -ldl -lm -s USE_ZLIB -s USE_BZIP2 --preload-file ../usr
+emcc -Os -o python.html Programs/python.o libpython3.11d.a Modules/_decimal/libmpdec/libmpdec.a Modules/expat/libexpat.a -ldl -lm -s USE_ZLIB --preload-file ../usr
 popd

--- a/config.site-wasm
+++ b/config.site-wasm
@@ -21,6 +21,9 @@ ac_cv_func_prlimit=no
 # unsupported syscall, https://github.com/emscripten-core/emscripten/issues/13393
 ac_cv_func_shutdown=no
 
+# breaks build, see https://github.com/ethanhs/python-wasm/issues/16
+ac_cv_lib_bz2_BZ2_bzCompress=no
+
 # The rest is based on pyodide
 # https://github.com/pyodide/pyodide/blob/main/cpython/pyconfig.undefs.h
 


### PR DESCRIPTION
emscripten port of bzip2 defines a ``main`` function in ``libbz2.a``.

See: https://github.com/ethanhs/python-wasm/issues/16