### PR TITLE
Deploy to Github Pages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - main
+    types: [opened, synchronize, reopened, closed]
   pull_request:
     branches:
       - main
@@ -70,3 +71,22 @@ jobs:
             cpython/builddir/host/Modules/expat/libexpat.a
             cpython/builddir/host/Programs/python.o
           if-no-files-found: error
+  ghpages:
+    name: "Upload to GitHub pages"
+    runs-on: "ubuntu-latest"
+    needs: emscripten
+    if: github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/download-artifact@v2
+        with:
+          name: wasm
+          path: wasm
+      - name: "Prepare artifacts for Github Pages"
+        run: |
+          mv wasm/python.html wasm/index.html
+      - name: Deploy CPython on WASM 🚀
+        uses: JamesIves/github-pages-deploy-action@4.1.7
+        with:
+          branch: gh-pages
+          folder: wasm


### PR DESCRIPTION
I just renamed `python.html` to `index.html` so we don't have to point people to `/python.html`.

Also at some point we should probably only build this from the nightly cron jobs, but since we are going to be squashing a lot of bugs, we probably want just whatever is latest deployed.