### PR TITLE
do not use system python3 for serving wasm files

### DIFF
--- a/browser-ui/server.py
+++ b/browser-ui/server.py
@@ -3,7 +3,7 @@
 import mimetypes
 
 mimetypes.init()
-if not ".wasm" in mimetypes.types_map:
+if ".wasm" not in mimetypes.types_map:
     mimetypes.types_map[".wasm"] = "application/wasm"
 
 import argparse

--- a/browser-ui/server.py
+++ b/browser-ui/server.py
@@ -4,7 +4,7 @@ import mimetypes
 
 mimetypes.init()
 if ".wasm" not in mimetypes.types_map:
-    mimetypes.types_map[".wasm"] = "application/wasm"
+    mimetypes.add_type("application/wasm", ".wasm")
 
 import argparse
 from http import server

--- a/browser-ui/server.py
+++ b/browser-ui/server.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python
 
+import mimetypes
+mimetypes.add_type(".wasm", "application/wasm")
+
 import argparse
 from http import server
 

--- a/browser-ui/server.py
+++ b/browser-ui/server.py
@@ -1,7 +1,10 @@
 #!/usr/bin/env python
 
 import mimetypes
-mimetypes.add_type(".wasm", "application/wasm")
+
+mimetypes.init()
+if not ".wasm" in mimetypes.types_map:
+    mimetypes.types_map[".wasm"] = "application/wasm"
 
 import argparse
 from http import server

--- a/run-python-browser.sh
+++ b/run-python-browser.sh
@@ -4,5 +4,5 @@ cp cpython/builddir/emscripten-browser/python.* browser-ui/worker/
 
 pushd .
 cd browser-ui
-python3 server.py $@
+../cpython/builddir/build/python server.py $@
 popd

--- a/run-python-browser.sh
+++ b/run-python-browser.sh
@@ -4,5 +4,5 @@ cp cpython/builddir/emscripten-browser/python.* browser-ui/worker/
 
 pushd .
 cd browser-ui
-../cpython/builddir/build/python server.py $@ || python3 server.py $@
+python3 server.py $@
 popd

--- a/run-python-browser.sh
+++ b/run-python-browser.sh
@@ -4,5 +4,5 @@ cp cpython/builddir/emscripten-browser/python.* browser-ui/worker/
 
 pushd .
 cd browser-ui
-../cpython/builddir/build/python server.py $@
+../cpython/builddir/build/python server.py $@ || python3 server.py $@
 popd


### PR DESCRIPTION
The wasm mimetype is not present in < 3.9  so instantiate streaming could fail silently on chrome and firefox
The host build is expected to be the latest Python available so just use it instead of any older system one