### PR TITLE
Trigger GitHub Pages upload on push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,7 +106,7 @@ jobs:
     runs-on: "ubuntu-latest"
     needs: emscripten
     # Relies on `on` restricting which branches trigger this job.
-    if: github.event_name == "push"
+    if: ${{ github.event_name == 'push' }}
     steps:
       - uses: actions/checkout@v2
       - uses: actions/download-artifact@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,7 +105,8 @@ jobs:
     name: "Upload to GitHub pages"
     runs-on: "ubuntu-latest"
     needs: emscripten
-    if: github.event.pull_request.merged == true
+    # Relies on `on` restricting which branches trigger this job.
+    if: github.event_name == "push"
     steps:
       - uses: actions/checkout@v2
       - uses: actions/download-artifact@v2


### PR DESCRIPTION
Closes #58

See https://docs.github.com/en/actions/learn-github-actions/contexts#example-contents-of-the-github-context as an example of a payload for a `push` event.