### PR TITLE
Support unicode in stdout and stderr

### DIFF
--- a/browser-ui/wasm-terminal.js
+++ b/browser-ui/wasm-terminal.js
@@ -91,8 +91,11 @@ export class WasmTerminal {
     this.xterm.clear();
   }
 
-  print(message) {
-    const normInput = message.replace(/[\r\n]+/g, "\n").replace(/\n/g, "\r\n");
-    this.xterm.write(normInput);
+  print(charCode) {
+    let array = [charCode];
+    if (charCode == 10) {
+      array = [13, 10];  // Replace \n with \r\n
+    }
+    this.xterm.write(new Uint8Array(array));
   }
 }

--- a/browser-ui/worker/worker.js
+++ b/browser-ui/worker/worker.js
@@ -35,15 +35,11 @@ class StdinBuffer {
     }
 }
 
-const stdoutBufSize = 128;
-const stdoutBuf = new Int32Array()
-let index = 0;
-
 const stdout = (charCode) => {
     if (charCode) {
         postMessage({
             type: 'stdout',
-            stdout: String.fromCharCode(charCode),
+            stdout: charCode,
         })
     } else {
         console.log(typeof charCode, charCode)
@@ -54,7 +50,7 @@ const stderr = (charCode) => {
     if (charCode) {
         postMessage({
             type: 'stderr',
-            stderr: String.fromCharCode(charCode),
+            stderr: charCode,
         })
     } else {
         console.log(typeof charCode, charCode)


### PR DESCRIPTION
This solution delegates the UTF-8 decoding to xterm.js, which accepts a `Uint8Array` object representing UTF-8 bytes to its `write` method ([docs here](https://xtermjs.org/docs/guides/encoding/)).

Thanks to @pmp-p for helping me realize that xterm.js might be able to do the decoding for us.