### PR TITLE
Add buffer for pasted stdin and inactive stdin

### DIFF
--- a/browser-ui/wasm-terminal.js
+++ b/browser-ui/wasm-terminal.js
@@ -1,7 +1,40 @@
+class BufferQueue {
+
+  constructor(xterm) {
+    this.buffer = [];
+  }
+
+  isEmpty() {
+    return this.buffer.length == 0;
+  }
+
+  lastLineIsIncomplete() {
+    return !this.isEmpty() && !this.buffer[this.buffer.length-1].endsWith("\n");
+  }
+
+  hasLineReady() {
+    return !this.isEmpty() && this.buffer[0].endsWith("\n");
+  }
+
+  addData(data) {
+    let lines = data.split(/(?<=\n)/g);
+    if (this.lastLineIsIncomplete()) {
+      this.buffer[this.buffer.length-1] += lines.shift();
+    }
+    for (let line of lines) {
+      this.buffer.push(line);
+    }
+  }
+
+  nextLine() {
+    return this.buffer.shift();
+  }
+}
 
 export class WasmTerminal {
 
   constructor() {
+    this.inputBuffer = new BufferQueue();
     this.input = ''
     this.resolveInput = null
     this.activeInput = false
@@ -25,39 +58,56 @@ export class WasmTerminal {
     this.xterm.open(container);
   }
 
-  handleReadComplete(lastChar) {
-    this.resolveInput(this.input + lastChar)
-    this.activeInput = false
-  }
-
   handleTermData = (data) => {
-    if (!this.activeInput) {
-      return
-    }
     const ord = data.charCodeAt(0);
-    let ofs;
 
+    data = data.replace(/\r\n|\r|\n/g, "\n")
+    if (data.length > 1 && data.includes("\n")) {
+      // Handle pasted data
+      let alreadyWritten = 0;
+      if (this.input != '') {
+        // If line already had data on it, merge pasted data with it
+        this.inputBuffer.addData(this.input);
+        alreadyWritten = this.input.length;
+        this.input = '';
+      }
+      this.inputBuffer.addData(data);
+      if (this.activeInput) {
+        let line = this.inputBuffer.nextLine();
+        this.writeLine(line.slice(alreadyWritten));
+        this.resolveInput(line);
+        this.activeInput = false;
+      }
+    } else if (!this.activeInput) {
+      this.inputBuffer.addData(data);
     // TODO: Handle ANSI escape sequences
-    if (ord === 0x1b) {
+    } else if (ord === 0x1b) {
     // Handle special characters
     } else if (ord < 32 || ord === 0x7f) {
       switch (data) {
         case "\r": // ENTER
         case "\x0a": // CTRL+J
         case "\x0d": // CTRL+M
-          this.xterm.write('\r\n');
-          this.handleReadComplete('\n');
+          this.resolveInput(this.input + this.writeLine('\n'));
+          this.input = '';
+          this.activeInput = false;
           break;
         case "\x7F": // BACKSPACE
         case "\x08": // CTRL+H
         case "\x04": // CTRL+D
           this.handleCursorErase(true);
           break;
-        
+
       }
     } else {
       this.handleCursorInsert(data);
     }
+  }
+
+  writeLine(line) {
+    this.xterm.write(line.slice(0, -1))
+    this.xterm.write('\r\n');
+    return line;
   }
 
   handleCursorInsert(data) {
@@ -79,9 +129,17 @@ export class WasmTerminal {
     this.activeInput = true
     // Hack to allow stdout/stderr to finish before we figure out where input starts
     setTimeout(() => {this.inputStartCursor = this.xterm.buffer.active.cursorX}, 1)
+    if (this.inputBuffer.hasLineReady()) {
+        return new Promise((resolve, reject) => {
+          resolve(this.writeLine(this.inputBuffer.nextLine()));
+          this.activeInput = false;
+        })
+    } else if (this.inputBuffer.lastLineIsIncomplete()) {
+      // Hack to ensure cursor input start doesn't end up after user input
+      setTimeout(() => {this.handleCursorInsert(this.inputBuffer.nextLine())}, 1);
+    }
     return new Promise((resolve, reject) => {
       this.resolveInput = (value) => {
-        this.input = ''
         resolve(value)
       }
     })


### PR DESCRIPTION
It took me a while to figure out what to hook into, but I believe I finally got standard input working the way I'd expect it to.

Improvements:

1. When multi-line text is pasted it displays as expected and also runs as expected
2. When text is typed while code is currently running, the typed text shows up only when standard input is prompt again
3. Partial data (when the pasted text doesn't end in a newline or when some text is typed and then some is pasted) shows up as expected

I added a separate class because the code started to feel unwieldy after I initially added all the buffering to the existing class. Happy to refactor if desired.

This along with unicode support (there's another PR for that) make this REPL feel pretty much like a native one from my testing (just need to add support for using Ctrl+L to clear the screen). 😁