### PR TITLE
Build and test WASI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,7 +183,7 @@ jobs:
         run: docker run --rm -v $(pwd):/build -w /build quay.io/tiran/cpythonbuild:emsdk3 ./test-wasi.sh
         # some WASI tests are failing
         continue-on-error: true
-      - name: "Upload node build artifacts"
+      - name: "Upload WASI artifacts"
         uses: actions/upload-artifact@v2
         with:
           name: wasi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,6 @@ jobs:
           test -e cpython/builddir/emscripten-node/python.wasm || exit 1
       - name: "Print test.pythoninfo"
         run: docker run --rm -v $(pwd):/build -w /build quay.io/tiran/cpythonbuild:emsdk3 ./run-python-node.sh -m test.pythoninfo
-        continue-on-error: true
       - name: "Run tests"
         run: docker run --rm -v $(pwd):/build -w /build quay.io/tiran/cpythonbuild:emsdk3 ./test-emscripten-node.sh
       - name: "Upload node build artifacts"
@@ -80,6 +79,7 @@ jobs:
             cpython/builddir/emscripten-node/python.wasm
             cpython/builddir/emscripten-node/python.worker.js
             cpython/builddir/emscripten-node/python.js
+            cpython/builddir/emscripten-node/build/lib.emscripten-wasm32-3.*/_sysconfigdata__emscripten_wasm32-emscripten.py
           if-no-files-found: error
       - name: "Upload build artifacts"
         uses: actions/upload-artifact@v2
@@ -90,6 +90,7 @@ jobs:
             cpython/builddir/emscripten-node/config.cache
             cpython/builddir/emscripten-node/Makefile
             cpython/builddir/emscripten-node/pyconfig.h
+            cpython/builddir/emscripten-node/pybuilddir.txt
             cpython/builddir/emscripten-node/libpython*.a
             cpython/builddir/emscripten-node/Modules/Setup.local
             cpython/builddir/emscripten-node/Modules/Setup.stdlib
@@ -143,6 +144,7 @@ jobs:
             cpython/builddir/emscripten-browser/config.cache
             cpython/builddir/emscripten-browser/Makefile
             cpython/builddir/emscripten-browser/pyconfig.h
+            cpython/builddir/emscripten-browser/pybuilddir.txt
             cpython/builddir/emscripten-browser/libpython*.a
             cpython/builddir/emscripten-browser/Modules/Setup.local
             cpython/builddir/emscripten-browser/Modules/Setup.stdlib
@@ -150,6 +152,62 @@ jobs:
             cpython/builddir/emscripten-browser/Modules/_decimal/libmpdec/libmpdec.a
             cpython/builddir/emscripten-browser/Modules/expat/libexpat.a
             cpython/builddir/emscripten-browser/Programs/python.o
+          if-no-files-found: error
+  wasi:
+    name: "Build WASI"
+    runs-on: "ubuntu-latest"
+    needs: build-python
+    steps:
+      - name: "checkout python-wasm"
+        uses: "actions/checkout@v2"
+      - name: "Fetch cached build Python"
+        uses: actions/cache@v2
+        with:
+          path: cpython
+          key: cpython-${{ runner.os }}-${{ github.sha }}
+      - name: "Check build Python"
+        run: |
+          test -e cpython/builddir/build/python || exit 1
+          test -e cpython/configure || exit 2
+      - name: "Common prepare step"
+        uses: ./.github/actions/prepare
+      - name: "Build WASI Python"
+        run: docker run --rm -v $(pwd):/build -w /build quay.io/tiran/cpythonbuild:emsdk3 ./build-python-wasi.sh
+      - name: "Check artifacts"
+        run: |
+          ls -la --si cpython/builddir/wasi/python*
+          test -e cpython/builddir/wasi/python.wasm || exit 1
+      - name: "Print test.pythoninfo"
+        run: docker run --rm -v $(pwd):/build -w /build quay.io/tiran/cpythonbuild:emsdk3 ./run-python-wasi.sh -m test.pythoninfo
+      - name: "Run tests"
+        run: docker run --rm -v $(pwd):/build -w /build quay.io/tiran/cpythonbuild:emsdk3 ./test-wasi.sh
+        # some WASI tests are failing
+        continue-on-error: true
+      - name: "Upload node build artifacts"
+        uses: actions/upload-artifact@v2
+        with:
+          name: wasi
+          path: |
+            cpython/builddir/wasi/python.wasm
+            cpython/builddir/wasi/build/lib.wasi-wasm32-3.*/_sysconfigdata__wasi_wasm32-wasi.py
+          if-no-files-found: error
+      - name: "Upload build artifacts"
+        uses: actions/upload-artifact@v2
+        with:
+          name: build-wasi
+          path: |
+            cpython/builddir/wasi/config.log
+            cpython/builddir/wasi/config.cache
+            cpython/builddir/wasi/Makefile
+            cpython/builddir/wasi/pybuilddir.txt
+            cpython/builddir/wasi/pyconfig.h
+            cpython/builddir/wasi/libpython*.a
+            cpython/builddir/wasi/Modules/Setup.local
+            cpython/builddir/wasi/Modules/Setup.stdlib
+            cpython/builddir/wasi/Modules/config.c
+            cpython/builddir/wasi/Modules/_decimal/libmpdec/libmpdec.a
+            cpython/builddir/wasi/Modules/expat/libexpat.a
+            cpython/builddir/wasi/Programs/python.o
           if-no-files-found: error
   ghpages:
     name: "Upload to GitHub pages"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,7 @@ jobs:
             cpython/builddir/emscripten-node/python.wasm
             cpython/builddir/emscripten-node/python.worker.js
             cpython/builddir/emscripten-node/python.js
+            cpython/builddir/emscripten-node/pybuilddir.txt
             cpython/builddir/emscripten-node/build/lib.emscripten-wasm32-3.*/_sysconfigdata__emscripten_wasm32-emscripten.py
           if-no-files-found: error
       - name: "Upload build artifacts"
@@ -90,7 +91,6 @@ jobs:
             cpython/builddir/emscripten-node/config.cache
             cpython/builddir/emscripten-node/Makefile
             cpython/builddir/emscripten-node/pyconfig.h
-            cpython/builddir/emscripten-node/pybuilddir.txt
             cpython/builddir/emscripten-node/libpython*.a
             cpython/builddir/emscripten-node/Modules/Setup.local
             cpython/builddir/emscripten-node/Modules/Setup.stdlib
@@ -189,6 +189,7 @@ jobs:
           name: wasi
           path: |
             cpython/builddir/wasi/python.wasm
+            cpython/builddir/wasi/pybuilddir.txt
             cpython/builddir/wasi/build/lib.wasi-wasm32-3.*/_sysconfigdata__wasi_wasm32-wasi.py
           if-no-files-found: error
       - name: "Upload build artifacts"
@@ -199,7 +200,6 @@ jobs:
             cpython/builddir/wasi/config.log
             cpython/builddir/wasi/config.cache
             cpython/builddir/wasi/Makefile
-            cpython/builddir/wasi/pybuilddir.txt
             cpython/builddir/wasi/pyconfig.h
             cpython/builddir/wasi/libpython*.a
             cpython/builddir/wasi/Modules/Setup.local

--- a/build-python-wasi.sh
+++ b/build-python-wasi.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -e
+
+# https://github.com/WebAssembly/wasi-sdk
+WASI_SDK=/opt/wasi-sdk
+# https://github.com/singlestore-labs/wasix
+WASIX_DIR=/opt/wasix
+
+export PATH=${WASI_SDK}/bin:$PATH
+export CC="ccache ${WASI_SDK}/bin/clang"
+export LDSHARED="${WASI_SDK}/bin/wasm-ld"
+export AR="${WASI_SDK}/bin/llvm-ar"
+
+export CFLAGS="-isystem ${WASIX_DIR}/include"
+export LDFLAGS="-L${WASIX_DIR}/lib -lwasix"
+
+mkdir -p cpython/builddir/wasi
+
+pushd cpython/builddir/wasi
+CONFIG_SITE=../../Tools/wasm/config.site-wasm32-wasi \
+  ../../configure -C \
+    --host=wasm32-unknown-wasi \
+    --build=$(../../config.guess) \
+    --with-build-python=$(pwd)/../build/python \
+    --disable-ipv6
+
+make -j$(nproc)
+
+popd

--- a/build-python-wasi.sh
+++ b/build-python-wasi.sh
@@ -26,4 +26,11 @@ CONFIG_SITE=../../Tools/wasm/config.site-wasm32-wasi \
 
 make -j$(nproc)
 
+# XXX hack
+# Symlink pybuilddir.txt and build lib directory with sysconfig data into
+# VPATH root. "--mapdir .::../../" uses VPATH root as CWD.
+mkdir -p ../../build
+ln -srf -t ../../ pybuilddir.txt
+ln -srf -t ../../build/ build/lib.wasi-wasm32-3.*
+
 popd

--- a/run-python-wasi.sh
+++ b/run-python-wasi.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -e
+
+export PATH="$PATH:/root/.wasmtime/bin"
+
+cd cpython/builddir/wasi
+# XXX hack, symlink sysconfig data into stdlib directory
+ln -srf -t ../../Lib/ build/lib.wasi-wasm32-3.*/_sysconfigdata__wasi_wasm32-wasi.py
+exec wasmtime run --mapdir .::../../ -- python.wasm "$@"

--- a/run-python-wasi.sh
+++ b/run-python-wasi.sh
@@ -4,6 +4,4 @@ set -e
 export PATH="$PATH:/root/.wasmtime/bin"
 
 cd cpython/builddir/wasi
-# XXX hack, symlink sysconfig data into stdlib directory
-ln -srf -t ../../Lib/ build/lib.wasi-wasm32-3.*/_sysconfigdata__wasi_wasm32-wasi.py
 exec wasmtime run --mapdir .::../../ -- python.wasm "$@"

--- a/test-wasi.sh
+++ b/test-wasi.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -e
+
+exec ./run-python-wasi.sh -m test "$@"


### PR DESCRIPTION
Add ``wasm32-wasi`` target to CI. The build depends on WASI SDK 15.0, latest WASIX, and wasmtime >= 0.36. About 25 test suites are failing, mostly due to lack of ``chmod`` and ``chown`` syscall support.

See: #18