### PR TITLE
Execute with bigint, chdir into build dir

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,6 +202,8 @@ jobs:
         run: |
           ls -la --si cpython/builddir/wasi/python*
           test -e cpython/builddir/wasi/python.wasm || exit 1
+      - name: "list"
+        run: docker run --rm -v $(pwd):/build -w /build quay.io/tiran/cpythonbuild:emsdk3 ls
       - name: "Print test.pythoninfo"
         run: docker run --rm -v $(pwd):/build -w /build quay.io/tiran/cpythonbuild:emsdk3 ./run-python-wasi.sh -m test.pythoninfo
       - name: "Run tests"

--- a/run-python-node.sh
+++ b/run-python-node.sh
@@ -1,4 +1,9 @@
 #!/usr/bin/env bash
+set -e
 
-exec node --experimental-wasm-threads --experimental-wasm-bulk-memory \
-    cpython/builddir/emscripten-node/python.js "$@"
+pushd cpython/builddir/emscripten-node
+exec node \
+    --experimental-wasm-threads \
+    --experimental-wasm-bulk-memory \
+    --experimental-wasm-bigint \
+    python.js "$@"

--- a/run-python-wasi.sh
+++ b/run-python-wasi.sh
@@ -3,8 +3,10 @@ set -e
 
 export PATH="$PATH:/root/.wasmtime/bin"
 
+cd cpython/builddir/wasi
+
 # PYTHONPATH is relative to mapped cpython/ directory.
 exec wasmtime run \
-    --env PYTHONPATH=/builddir/wasi/$(cat cpython/builddir/wasi/pybuilddir.txt) \
+    --env PYTHONPATH=/builddir/wasi/$(cat pybuilddir.txt) \
     --mapdir /::cpython/ -- \
-    cpython/builddir/wasi/python.wasm "$@"
+    python.wasm "$@"

--- a/test-emscripten-node.sh
+++ b/test-emscripten-node.sh
@@ -1,6 +1,4 @@
 #!/usr/bin/env bash
 set -e
 
-exec node --experimental-wasm-threads --experimental-wasm-bulk-memory \
-    cpython/builddir/emscripten-node/python.js \
-    -m test "$@"
+exec ./run-python-node.sh -m test "$@"

--- a/test-wasi.sh
+++ b/test-wasi.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 set -e
 
 exec ./run-python-wasi.sh -m test "$@"


### PR DESCRIPTION
- Python now needs bigint support from Node.
- Change into directory to make execution consistent with buildbot and makefile.
- Run without DAC override capability to fix some tests that fail with DAC.